### PR TITLE
feat(004) add function invoker

### DIFF
--- a/004-function-invoker.js
+++ b/004-function-invoker.js
@@ -1,0 +1,10 @@
+function invoker(fn, args) {
+    const params = fn
+        .toString()
+        .match(/\((.+?)\)/)[1]
+        .split(', ')
+        .map(param => args[param]);
+    return fn.apply(fn, params);
+}
+
+invoker(function(a, b, c, d) {}, {a: 1, b: 2, d: 4}); // as function(1, 2, undefined, 4)


### PR DESCRIPTION
RegExp could be also replaced with something like:
`const start = str.indexOf('(');
const end = str.indexOf(')');
`